### PR TITLE
Fix for nginx crush

### DIFF
--- a/web/config/nginx/default.conf
+++ b/web/config/nginx/default.conf
@@ -8,7 +8,7 @@ server {
 
   #listen [::]:80 default_server ipv6only=on; ## listen for ipv6
 
-  server_name * localhost;
+  server_name "" localhost;
 
   #ssl_protocols       TLSv1 TLSv1.1 TLSv1.2; # SSLv3 исключить CVE-2014-3566
   


### PR DESCRIPTION
nginx doesn't accept * as value of server_name config variable (see https://nginx.org/ru/docs/http/server_names.html)

Correct value for "all" is empty string "".